### PR TITLE
Add CSV import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - 🔐 Senhas armazenadas como hash SHA-256 (apenas proteção básica)
 - ✅ Interface limpa, responsiva e sem anúncios
 - ✅ Exportação de dados em CSV
+- ✅ Importação de dados via CSV
 
 ---
 
@@ -46,6 +47,12 @@ considerado uma criptografia forte.
    ```
 
 3. Abra o arquivo `index.html` diretamente no navegador.
+
+### Restaurar dados de um CSV
+
+1. No menu **Configurações**, clique em **Importar CSV**.
+2. Selecione o arquivo exportado anteriormente.
+3. As transações serão carregadas imediatamente no histórico.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -438,6 +438,9 @@
                     <button id="export-csv-btn" class="w-full bg-blue-500 hover:bg-blue-600 font-bold py-3 rounded-lg flex items-center justify-center space-x-2 transition-colors">
                         <i data-lucide="download"></i><span>Exportar Dados para .CSV</span>
                     </button>
+                    <button id="import-csv-btn" class="w-full bg-blue-500 hover:bg-blue-600 font-bold py-3 rounded-lg flex items-center justify-center space-x-2 transition-colors">
+                        <i data-lucide="upload"></i><span>Importar CSV</span>
+                    </button>
                 </div>
                 <div class="bg-gray-800 p-4 rounded-xl space-y-4">
                     <h3 class="text-lg font-semibold text-white">Segurança</h3>
@@ -616,6 +619,7 @@
                 
                 // Settings Page
                 if(target.id === 'export-csv-btn') handleExportCSV();
+                if(target.id === 'import-csv-btn') handleImportCSV();
                 if(target.id === 'register-biometrics-btn') handleRegisterBiometrics();
 
             };
@@ -687,6 +691,61 @@
             link.href = URL.createObjectURL(blob);
             link.download = `Reis_export_${user.username}_${new Date().toISOString().split('T')[0]}.csv`;
             link.click();
+        };
+
+        const handleImportCSV = () => {
+            const input = document.createElement('input');
+            input.type = 'file';
+            input.accept = '.csv';
+            input.style.display = 'none';
+
+            input.onchange = (e) => {
+                const file = e.target.files[0];
+                if (!file) return;
+                const reader = new FileReader();
+                reader.onload = (ev) => {
+                    const text = ev.target.result.trim();
+                    const lines = text.split(/\r?\n/).slice(1); // remove header
+                    const imported = [];
+                    for (const line of lines) {
+                        if (!line) continue;
+                        const values = [];
+                        let current = '';
+                        let inside = false;
+                        for (let i = 0; i < line.length; i++) {
+                            const ch = line[i];
+                            if (ch === '"') {
+                                if (inside && line[i + 1] === '"') { current += '"'; i++; }
+                                else inside = !inside;
+                            } else if (ch === ',' && !inside) {
+                                values.push(current);
+                                current = '';
+                            } else {
+                                current += ch;
+                            }
+                        }
+                        values.push(current);
+                        if (values.length < 5) continue;
+                        imported.push({
+                            id: crypto.randomUUID(),
+                            date: values[0],
+                            description: values[1],
+                            category: values[2],
+                            amount: parseFloat(values[3]),
+                            type: values[4]
+                        });
+                    }
+                    AppState.transactions = AppState.transactions.concat(imported);
+                    AppState.transactions.sort((a, b) => new Date(b.date) - new Date(a.date));
+                    DataProvider.saveData(AppState.user.id, 'transactions', AppState.transactions);
+                    updateUI();
+                };
+                reader.readAsText(file);
+            };
+
+            document.body.appendChild(input);
+            input.click();
+            input.remove();
         };
 
         const handleRegisterBiometrics = async () => {


### PR DESCRIPTION
## Summary
- add Import CSV button in settings
- allow importing transactions from CSV files
- wire new button into UI
- document import/restore instructions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842d0a268188330981fb155bb0c5821