### PR TITLE
Implement mobile sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,8 @@
             recurring: [],
             isLoading: true,
             transactionToEdit: null,
-            showTransactionForm: false
+            showTransactionForm: false,
+            isSidebarOpen: false
         };
 
         // --- UTILITIES (WebAuthn & Data Helpers) ---
@@ -224,20 +225,30 @@
         };
         
         const renderMainLayout = () => {
-            const { view } = AppState;
+            const { view, isSidebarOpen } = AppState;
             const navItem = (targetView, icon, label) => `
                 <button data-view="${targetView}" class="nav-item flex flex-col items-center justify-center space-y-1 w-full p-2 rounded-lg transition-colors ${view === targetView ? 'bg-teal-500/20 text-teal-400' : 'text-gray-400 hover:bg-gray-700'}">
                     <i data-lucide="${icon}" class="w-6 h-6"></i>
                     <span class="text-xs font-medium">${label}</span>
                 </button>
             `;
+            const navClasses = `transform transition-transform md:transform-none ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'} fixed top-0 left-0 h-full w-64 bg-gray-800/90 backdrop-blur-sm p-4 flex flex-col space-y-4 md:static md:h-auto md:w-24 md:translate-x-0 md:bg-gray-800/50 md:p-2 z-20 border-r border-gray-700`;
             return `
                 <div class="min-h-screen text-white font-sans flex flex-col md:flex-row">
-                    <nav class="fixed bottom-0 left-0 w-full md:static md:w-24 bg-gray-800/50 backdrop-blur-sm p-2 flex md:flex-col justify-around md:justify-start md:space-y-4 order-last md:order-first border-t md:border-t-0 md:border-r border-gray-700 z-10">
-                        ${navItem('dashboard', 'home', 'Início')}
-                        ${navItem('transactions', 'receipt', 'Lançar')}
-                        ${navItem('recurring', 'repeat', 'Recorrências')}
-                        ${navItem('budgets', 'piggy-bank', 'Orçamento')}
+                    <header class="md:hidden flex items-center bg-gray-800/50 backdrop-blur-sm p-2">
+                        <button id="menu-toggle" class="text-gray-400 hover:text-teal-400">
+                            <i data-lucide="menu" class="w-6 h-6"></i>
+                        </button>
+                        <h1 class="flex-1 text-center font-semibold">R\u00e9is</h1>
+                    </header>
+
+                    <div id="sidebar-backdrop" class="fixed inset-0 bg-black/50 ${isSidebarOpen ? '' : 'hidden'} md:hidden z-10"></div>
+
+                    <nav class="${navClasses}">
+                        ${navItem('dashboard', 'home', 'In\u00edcio')}
+                        ${navItem('transactions', 'receipt', 'Lan\u00e7ar')}
+                        ${navItem('recurring', 'repeat', 'Recorr\u00eancias')}
+                        ${navItem('budgets', 'piggy-bank', 'Or\u00e7amento')}
                         ${navItem('settings', 'settings', 'Ajustes')}
                         <div class="md:mt-auto">
                             <button id="logout-btn" class="flex flex-col items-center justify-center space-y-1 w-full p-2 rounded-lg transition-colors text-gray-400 hover:bg-gray-700">
@@ -246,8 +257,8 @@
                             </button>
                         </div>
                     </nav>
-                    
-                    <main id="main-content" class="flex-1 overflow-y-auto pb-20 md:pb-0">
+
+                    <main id="main-content" class="flex-1 overflow-y-auto">
                         <!-- Page content will be injected here -->
                     </main>
 
@@ -480,9 +491,7 @@
             if (view === 'auth') {
                 root.innerHTML = renderAuthPage();
             } else {
-                if (!document.getElementById('main-content')) {
-                    root.innerHTML = renderMainLayout();
-                }
+                root.innerHTML = renderMainLayout();
                 const mainContent = document.getElementById('main-content');
                 if (view === 'dashboard') mainContent.innerHTML = renderDashboard();
                 if (view === 'transactions') mainContent.innerHTML = renderTransactionsPage();
@@ -499,8 +508,12 @@
                 AppState.transactionToEdit = null;
             }
             AppState.view = newView;
+            AppState.isSidebarOpen = false;
             updateUI();
         };
+
+        const toggleSidebar = () => { AppState.isSidebarOpen = !AppState.isSidebarOpen; updateUI(); };
+        const closeSidebar = () => { if(AppState.isSidebarOpen){ AppState.isSidebarOpen = false; updateUI(); } };
 
         const loadDataForUser = (currentUser) => {
             if (!currentUser) return;
@@ -607,6 +620,8 @@
                 }
 
                 // Main Layout
+                if (target.id === 'menu-toggle') { toggleSidebar(); return; }
+                if (target.id === 'sidebar-backdrop') { closeSidebar(); return; }
                 if (target.matches('.nav-item')) switchView(target.dataset.view);
                 if (target.id === 'logout-btn') logout();
 


### PR DESCRIPTION
## Summary
- add sidebar open state in AppState
- render a slide‑out sidebar on mobile with backdrop and header
- close sidebar when changing pages
- allow menu button toggle through event listeners

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842e11d74288330a889bc84b6b69684